### PR TITLE
Interface Fix PR 

### DIFF
--- a/code/_onclick/hud/_defines.dm
+++ b/code/_onclick/hud/_defines.dm
@@ -102,9 +102,9 @@
 
 //Middle right (status indicators)
 #define ui_healthdoll "EAST-1:28,BOTTOM+2:7"
-#define ui_health "EAST-1:29,BOTTOM+3:1"
-#define ui_health_rad "EAST:8,BOTTOM+3:1"
-#define ui_health_stamina "EAST:18,BOTTOM+3:1"
+#define ui_health "EAST-1:29,BOTTOM+3.2:1"
+#define ui_health_rad "EAST:8,BOTTOM+3.2:1"
+#define ui_health_stamina "EAST:18,BOTTOM+3.2:1"
 #define ui_internal "EAST-1:28,CENTER:17"
 #define ui_mood "EAST-1:28,CENTER-3:10"
 

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -6,15 +6,15 @@
 
 // The default UI style is the first one in the list
 GLOBAL_LIST_INIT(available_ui_styles, list(
-	"Midnight2" = 'icons/mob/screen_midnight2.dmi',
-	"Stalker One" = 'icons/mob/screen_stalkir.dmi',
-	"Stalker Two" = 'icons/mob/screen_stalker.dmi',
-	"Retro" = 'icons/mob/screen_retro.dmi',
+//	"Midnight2" = 'icons/mob/screen_midnight2.dmi',
+//	"Stalker One" = 'icons/mob/screen_stalkir.dmi',
+//	"Stalker Two" = 'icons/mob/screen_stalker.dmi',
+//	"Retro" = 'icons/mob/screen_retro.dmi',
 	"Midnight" = 'icons/mob/screen_midnight.dmi',
-	"Plasmafire" = 'icons/mob/screen_plasmafire.dmi',
-	"Slimecore" = 'icons/mob/screen_slimecore.dmi',
-	"Operative" = 'icons/mob/screen_operative.dmi',
-	"Clockwork" = 'icons/mob/screen_clockwork.dmi'
+//	"Plasmafire" = 'icons/mob/screen_plasmafire.dmi',
+//	"Slimecore" = 'icons/mob/screen_slimecore.dmi',
+//	"Operative" = 'icons/mob/screen_operative.dmi',
+//	"Clockwork" = 'icons/mob/screen_clockwork.dmi'
 ))
 
 /proc/ui_style2icon(ui_style)

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -50,8 +50,8 @@
 	var/obj/screen/click_catcher/void
 
 	//These two vars are used to make a special mouse cursor, with a unique icon for clicking
-	var/mouse_up_icon = null
-	var/mouse_down_icon = null
+	var/mouse_up_icon = 'stalker/icons/cursors.dmi'
+	var/mouse_down_icon = 'stalker/icons/cursors.dmi'
 
 	var/ip_intel = "Disabled"
 
@@ -77,3 +77,5 @@
 	var/list/char_render_holders			//Should only be a key-value list of north/south/east/west = obj/screen.
 
 	var/country = null
+
+	mouse_pointer_icon = 'stalker/icons/cursors.dmi'

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -35,7 +35,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/toggles = TOGGLES_DEFAULT
 	var/db_flags
 	var/chat_toggles = TOGGLES_DEFAULT_CHAT
-	var/widescreen = TRUE
+	var/widescreen = FALSE
 	var/ghost_form = "ghost"
 	var/ghost_orbit = GHOST_ORBIT_CIRCLE
 	var/ghost_accs = GHOST_ACCS_DEFAULT_OPTION
@@ -463,7 +463,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<table><tr><td width='340px' height='300px' valign='top'>"
 			dat += "<h2>Main settings</h2>"
 			dat += "<div class='bflex'><b>UI Style:</b> <a href='?_src_=prefs;task=input;preference=ui'>[UI_style]</a></div>"
-			dat += "<div class='bflex'><b>Interface:</b> <a href='?_src_=prefs;preference=widescreen'>[(widescreen) ? "New" : "Old"]</a></div>"
+//			dat += "<div class='bflex'><b>Interface:</b> <a href='?_src_=prefs;preference=widescreen'>[(widescreen) ? "Do Not Use" : "Old"]</a></div>"
 			dat += "<div class='bflex'><b>tgui Monitors:</b> <a href='?_src_=prefs;preference=tgui_lock'>[(tgui_lock) ? "Primary" : "All"]</a></div>"
 			dat += "<div class='bflex'><b>tgui Style:</b> <a href='?_src_=prefs;preference=tgui_fancy'>[(tgui_fancy) ? "Fancy" : "No Frills"]</a></div>"
 			dat += "<br>"


### PR DESCRIPTION
- Fixes the health, rad health, and stamina bar so that its not right on top of the health doll
- Removes all other HUD options other than Midnight
- Changes the cursor into the STALKER cursor
- Disables the 'widescreen' interface so that the only HUD used is the 'old style'

Old
![image](https://user-images.githubusercontent.com/65364869/136364947-f1ebefa8-5238-421c-9e5f-8424fdf5505e.png)

New
![image](https://user-images.githubusercontent.com/65364869/136367333-a7ccb1c5-47a9-4306-a6e4-eebbffaa0d81.png)

Cursor now works as intended
![image](https://user-images.githubusercontent.com/65364869/136367533-49f2eca8-86af-4216-9661-b40b822fcdad.png)

Bad widescreen HUD that is now disabled
![image](https://user-images.githubusercontent.com/65364869/136367963-216033e9-9da0-431e-a3b1-17812d45ae03.png)

Much better HUD that is the only option now
![image](https://user-images.githubusercontent.com/65364869/136367944-827d58dd-4058-4cf1-8185-b776421ae3e4.png)
