### PR TITLE
Typing Indicator Fix

### DIFF
--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -23,7 +23,7 @@ SUBSYSTEM_DEF(input)
 // This is for when macro sets are eventualy datumized
 /datum/controller/subsystem/input/proc/setup_default_macro_sets()
 	var/list/static/default_macro_sets
-	
+
 	if(default_macro_sets)
 		macro_sets = default_macro_sets
 		return
@@ -32,22 +32,22 @@ SUBSYSTEM_DEF(input)
 		"default" = list(
 			"Tab" = "\".winset \\\"input.focus=true?map.focus=true input.background-color=[COLOR_INPUT_DISABLED]:input.focus=true input.background-color=[COLOR_INPUT_ENABLED]\\\"\"",
 			"O" = "ooc",
-			"T" = "say",
-			"M" = "me",
+			"T" = ".say",
+			"M" = ".me",
 			"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"", // This makes it so backspace can remove default inputs
 			"Any" = "\"KeyDown \[\[*\]\]\"",
 			"Any+UP" = "\"KeyUp \[\[*\]\]\"",
 			),
 		"old_default" = list(
 			"Tab" = "\".winset \\\"mainwindow.macro=old_hotkeys map.focus=true input.background-color=[COLOR_INPUT_DISABLED]\\\"\"",
-			"Ctrl+T" = "say",
+			"Ctrl+T" = ".say",
 			"Ctrl+O" = "ooc",
 			),
 		"old_hotkeys" = list(
 			"Tab" = "\".winset \\\"mainwindow.macro=old_default input.focus=true input.background-color=[COLOR_INPUT_ENABLED]\\\"\"",
 			"O" = "ooc",
-			"T" = "say",
-			"M" = "me",
+			"T" = ".say",
+			"M" = ".me",
 			"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"", // This makes it so backspace can remove default inputs
 			"Any" = "\"KeyDown \[\[*\]\]\"",
 			"Any+UP" = "\"KeyUp \[\[*\]\]\"",

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -1,7 +1,7 @@
 //Speech verbs.
 /mob/verb/say_typing_indicator()
-	set name = "Say"
-	set hidden = FALSE
+	set name = ".Say"
+	set hidden = TRUE
 	set category = "IC"
 	display_typing_indicator()
 	var/message = input(usr, "", "say") as text|null
@@ -12,13 +12,13 @@
 	return say_verb(message)
 
 /mob/verb/say_verb(message as text)
-	set name = "say_noindicator"
-	set hidden = TRUE
+	set name = "Say"
+
 	set category = "IC"
 	if(!length(message)) //If a null message somehow makes it through to this verb.
 		return
 	if(GLOB.say_disabled)	//This is here to try to identify lag problems
-		to_chat(usr, "<span class='danger'>Speech is currently admin-disableed.</span>")
+		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")
 		return
 	set_typing_indicator(FALSE)
 	if(message)
@@ -36,8 +36,8 @@
 	say(message, language) //only living mobs actually whisper, everything else just talks
 
 /mob/verb/me_typing_indicator()
-	set name = "Me"
-	set hidden = FALSE
+	set name = ".Me"
+	set hidden = TRUE
 	set category = "IC"
 	display_typing_indicator()
 	var/message = input(usr, "", "me") as message|null
@@ -48,8 +48,7 @@
 	return me_verb(message)
 
 /mob/verb/me_verb(message as text)
-	set name = "me_noindicator"
-	set hidden = TRUE
+	set name = "Me"
 	set category = "IC"
 
 	if(GLOB.say_disabled)	//This is here to try to identify lag problems


### PR DESCRIPTION
- Typing indicators will only appear if Say and Me are used via hotkey. This will allow players to use Say and Me expansion via command line once more.

pls start using hotkey mode