### PR TITLE
semi-random death screams

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -306,7 +306,7 @@
 			new_race = mrace
 		else
 			return
-		deathsound = new_race.deathsound
+//		deathsound = new_race.deathsound
 		dna.species.on_species_loss(src, new_race, pref_load)
 		var/datum/species/old_species = dna.species
 		dna.species = new_race

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -12,6 +12,7 @@
 	verbs += /mob/living/proc/lay_down
 
 	icon_state = ""		//Remove the inherent human icon that is visible on the map editor. We're rendering ourselves limb by limb, having it still be there results in a bug where the basic human icon appears below as south in all directions and generally looks nasty.
+	pickDeathSound()
 
 	//initialize limbs first
 	create_bodyparts()
@@ -34,6 +35,17 @@
 
 	AddComponent(/datum/component/redirect, list(COMSIG_COMPONENT_CLEAN_ACT = CALLBACK(src, .proc/clean_blood)))
 
+/mob/living/carbon/human/proc/pickDeathSound()
+	var/deathsound_pick
+	if(prob(1))
+		deathsound_pick = 'sound/voice/human/wilhelm_scream.ogg'
+	else
+		deathsound_pick = pick('sound/voice/human/malescream_1.ogg',
+									'sound/voice/human/malescream_2.ogg',
+									'sound/voice/human/malescream_3.ogg',
+									'sound/voice/human/malescream_4.ogg',
+									'sound/voice/human/malescream_5.ogg')
+		deathsound = deathsound_pick
 
 /mob/living/carbon/human/ComponentInitialize()
 	. = ..()


### PR DESCRIPTION
when Initialize() is called on /mob/living/carbon/human it chooses a random scream and they will retain that same scream in the event they are revived after death

dying will play the selected scream

I tried to get it to detect gender in the event a character with their gender var set to "female" was spawned but I couldn't get it to work (sorry Hip)

I also tried to get it to work with the *scream emote but I couldn't get that to work either for likely anomalous reasons