### PR TITLE
Mob Respawning Correction

### DIFF
--- a/code/controllers/subsystem/blowout.dm
+++ b/code/controllers/subsystem/blowout.dm
@@ -155,6 +155,11 @@ SUBSYSTEM_DEF(blowout)
 			H.apply_damage(200, PSY)
 		CHECK_TICK
 
+/datum/controller/subsystem/blowout/proc/BlowoutMobSpawns()
+	for(var/datum/controller/subsystem/zona/MS)
+		MS.SpawnMobs()
+		CHECK_TICK
+
 /datum/controller/subsystem/blowout/proc/StopBlowout()
 
 	if(blowoutphase == 2)
@@ -236,6 +241,8 @@ SUBSYSTEM_DEF(blowout)
 			add_lenta_message(null, "0", "Sidorovich", "Loners", "For PDA [name_] get [GetCostBasedOnReputation(rep_)] roubles.")
 	add_lenta_message(null, "0", "Sidorovich", "Loners", "Search, kill and sell the PDAs of stalkers with bad reputations!")
 
+
+	BlowoutMobSpawns()//Calls 'SpawnMobs' on all active mob spawners.
 
 /datum/controller/subsystem/blowout/proc/ProcessBlowout()
 	if(isblowout)

--- a/stalker/code/whitelist.dm
+++ b/stalker/code/whitelist.dm
@@ -14,7 +14,7 @@ GLOBAL_PROTECT(st_whitelist)
 /proc/check_st_whitelist(ckey, job_title)
 	if(!GLOB.st_whitelist)
 		return FALSE
-	if(ckey == "malgover")
+	if(ckey == "marrone")
 		return TRUE
 	for (var/WL in GLOB.st_whitelist[ckey])
 		if (WL == job_title)


### PR DESCRIPTION
- - -
I didn't enable it prior by mistake. Whoops. It was only present in admin stopped blowouts. Even then, it didn't function.
Big oops.
- - -
Balance:
 - Mobs are now respawned on active landmarks at the very end of each blowout. If this causes issues, we'll remove it, but for now it should suffice. Mobs might stack in similar fashion to artefacts, which, again, might prove to be an issue that's easily removed.
- - -
Other:
Big Cheese Ckey replaced.