### PR TITLE
Whoops 2.0

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -68,9 +68,9 @@
 				else
 					to_chat(C, "<font color='[GLOB.normal_ooc_colour]'><span class='ooc'><span class='prefix'>OOC:</span> <EM>[holder.fakekey ? holder.fakekey : key]:</EM> <span class='message linkify'>[msg]</span></span></font>")
 			else if(!(key in C.prefs.ignoring))
-				to_chat(C, "<font color='[GLOB.normal_ooc_colour]'><span class='ooc'><span class='prefix'>[get_country_flag(country)] OOC:</span> <EM>[keyname]:</EM> <span class='message linkify'>[msg]</span></span></font>")
+				to_chat(C, "<font color='[GLOB.normal_ooc_colour]'><span class='ooc'><span class='prefix'>OOC:</span> <EM>[keyname]:</EM> <span class='message linkify'>[msg]</span></span></font>")
 	webhook_send_ooc(key, msg)
-
+/*
 /proc/get_country_flag(country)
 	if (!country)
 		return "N/A"
@@ -79,7 +79,7 @@
 		return sheet.icon_tag("flags-[country]")
 	else
 		return sheet.icon_tag("US")
-
+*/
 /proc/toggle_ooc(toggle = null)
 	if(toggle != null) //if we're specifically en/disabling ooc
 		if(toggle != GLOB.ooc_allowed)


### PR DESCRIPTION
Forgot to remove the prefix for flags in names, resulting in 'N/A' on all players registered as having a flag.
Can't see it locally, so this passed by me. My bad.