### PR TITLE
Admin Lifeline

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -523,7 +523,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	attack_verb = list("beat", "smacked", "bonked", "bludgened", "battered")
 	w_class = WEIGHT_CLASS_HUGE
 	slot_flags = ITEM_SLOT_BELT
-	var/homerun_ready = 0
+/*	var/homerun_ready = 0
 	var/homerun_able = 0
 
 obj/item/melee/baseball_bat/homerun
@@ -558,7 +558,7 @@ obj/item/melee/baseball_bat/homerun
 		return
 	else if(!target.anchored)
 		target.throw_at(throw_target, rand(1,2), 7, user)
-
+*/
 /obj/item/melee/baseball_bat/ablative
 	name = "metal baseball bat"
 	desc = "This bat is made of highly reflective, highly armored material."

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -163,7 +163,7 @@ generally it would be used like so:
 NOTE: it checks usr! not src! So if you're checking somebody's rank in a proc which they did not call
 you will have to do something like if(client.rights & R_ADMIN) yourself.
 */
-/proc/check_rights(rights_required, show_msg=1)
+/proc/check_rights(rights_required, show_msg=0)//Set to 0 because of the spawn check for rights. It's hacky and stupid, but it works. Sorry. -Carl
 	if(usr && usr.client)
 		if (check_rights_for(usr.client, rights_required))
 			return 1

--- a/stalker/code/whitelist.dm
+++ b/stalker/code/whitelist.dm
@@ -14,7 +14,7 @@ GLOBAL_PROTECT(st_whitelist)
 /proc/check_st_whitelist(ckey, job_title)
 	if(!GLOB.st_whitelist)
 		return FALSE
-	if(ckey == "marrone")
+	if(check_rights(R_ADMIN))
 		return TRUE
 	for (var/WL in GLOB.st_whitelist[ckey])
 		if (WL == job_title)


### PR DESCRIPTION
- - -
This is how you stop an admin's method of thinking. More at eleven. Ook ook monkey time.
- - -
Balance:
 - Bat can no longer homerun. :)
- - -
Misc:
 - Admins are now given the whitelists by default.
 - As a consequence of the above, permission check warnings no longer exist. It's hacky and shitty, but it works, so, y'know, whatever.
- - -