### PR TITLE
Scope Keybind

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -111,6 +111,9 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/list/modifications = list()
 	var/unique = 0
 
+/obj/item/proc/shiftv(mob/user)
+	return
+
 /obj/item/Initialize()
 
 	materials =	typelist("materials", materials)

--- a/code/modules/keybindings/bindings_human.dm
+++ b/code/modules/keybindings/bindings_human.dm
@@ -1,6 +1,11 @@
 /mob/living/carbon/human/key_down(_key, client/user)
 	if(client.keys_held["Shift"])
 		switch(_key)
+
+			if("V")
+				if(get_active_held_item() != null)
+					get_active_held_item().shiftv(src)
+
 			if("E") // Put held thing in belt or take out most recent thing from belt
 				var/obj/item/thing = get_active_held_item()
 				var/obj/item/equipped_belt = get_item_by_slot(SLOT_BELT)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -133,7 +133,7 @@
 		pin = new pin(src)
 	if(gun_light)
 		alight = new(src)
-	build_zooming()
+//	build_zooming()
 
 /obj/item/gun/Destroy()
 	QDEL_NULL(pin)
@@ -657,6 +657,9 @@
 	gun.zoom(L, FALSE)
 	..()
 
+/obj/item/gun/shiftv(mob/user)
+	if(zoomable)
+		zoom(user)
 
 /obj/item/gun/proc/zoom(mob/living/user, forced_zoom)
 	if(!user || !user.client)

--- a/stalker/code/objects/items/weapons/guns/shotgun.dm
+++ b/stalker/code/objects/items/weapons/guns/shotgun.dm
@@ -3,6 +3,7 @@
 
 /obj/item/gun/ballistic/shotgun/bm16  // Горизонталка
 	name = "BM-16"
+	desc = "The original BM16 rifle. Heavy and dangerous two barrel rifle, and it's effective in high range too."
 	eng_desc = "The original BM16 rifle. Heavy and dangerous two barrel rifle, and it's effective in high range too."
 	icon_state = "bm16"
 	item_state = "bm16"
@@ -50,6 +51,7 @@
 
 /obj/item/gun/ballistic/shotgun/bm16/toz34  //  Вертикалка
 	name = "TOZ-34"
+	desc = "This extremely common over-and-under hunting shotgun can offer better protection against mutants than a pistol, thanks to its accuracy and stopping power. Used mostly by rookies on the outskirts of the Zone."
 	eng_desc = "This extremely common over-and-under hunting shotgun can offer better protection against mutants than a pistol, thanks to its accuracy and stopping power. Used mostly by rookies on the outskirts of the Zone."
 	icon_state = "toz34"
 	item_state = "toz34"
@@ -67,6 +69,7 @@
 
 /obj/item/gun/ballistic/shotgun/ithaca  //  Ithaca M37
 	name = "Ithaca M37"
+	desc = " Pump-action shotgun made in large numbers for the civilian, military, and police markets. It utilizes a novel combination ejection/loading port on the bottom of the gun which leaves the sides closed to the elements. Since shotshells load and eject from the bottom, operation of the gun is equally convenient for both right and left hand shooters. This makes the gun popular with left-handed shooters. The model 37 is considered one of the most durable and reliable shotguns ever produced."
 	eng_desc = " Pump-action shotgun made in large numbers for the civilian, military, and police markets. It utilizes a novel combination ejection/loading port on the bottom of the gun which leaves the sides closed to the elements. Since shotshells load and eject from the bottom, operation of the gun is equally convenient for both right and left hand shooters. This makes the gun popular with left-handed shooters. The model 37 is considered one of the most durable and reliable shotguns ever produced."
 	icon_state = "ithacam37"
 	item_state = "ithacam37"
@@ -89,6 +92,7 @@
 
 /obj/item/gun/ballistic/shotgun/chaser  //  Winchester 1300
 	name = "Chaser-13"
+	desc = "A Western smoothbore shotgun that is extremely popular around the world thanks to its amazing reliability and faster reloading speed. Particularly valued for its functionality by the Zone's hunters. All of its parts are coated with an anticorrosion compound."
 	eng_desc = "A Western smoothbore shotgun that is extremely popular around the world thanks to its amazing reliability and faster reloading speed. Particularly valued for its functionality by the Zone's hunters. All of its parts are coated with an anticorrosion compound."
 	icon_state = "chaser"
 	item_state = "chaser"
@@ -110,6 +114,7 @@
 
 /obj/item/gun/ballistic/shotgun/bm16/sawnoff
 	name = "sawed-off BM-16"
+	desc = "A sawed-off hunting shotgun with two side-by-side barrels, making it lighter and more compact than a full shotgun. One of the most popular weapons among bandits due to its combination of ease of concealment and extreme effectiveness in close combat."
 	eng_desc = "A sawed-off hunting shotgun with two side-by-side barrels, making it lighter and more compact than a full shotgun. One of the most popular weapons among bandits due to its combination of ease of concealment and extreme effectiveness in close combat."
 	sawn_off = TRUE
 	weapon_weight = WEAPON_LIGHT
@@ -129,6 +134,7 @@
 
 /obj/item/gun/ballistic/shotgun/spsa
 	name = "SPAS-12"
+	desc = "This special purpose smoothbore automatic shotgun was designed in the second half of the 20th century and comes with pump-action and self-cocking firing modes. Used as an all-purpose weapon by the police and assault troops. Notable for its reliability and tactical flexibility. Despite its large weight, complex mechanism and considerable cost it is in demand in the Zone due to its effectiveness against mutants."
 	eng_desc = "This special purpose smoothbore automatic shotgun was designed in the second half of the 20th century and comes with pump-action and self-cocking firing modes. Used as an all-purpose weapon by the police and assault troops. Notable for its reliability and tactical flexibility. Despite its large weight, complex mechanism and considerable cost it is in demand in the Zone due to its effectiveness against mutants."
 	icon_state = "spsa"	//Нужно добавить
 	item_state = "spsa" //Нужно добавить
@@ -152,6 +158,7 @@
 
 /obj/item/gun/ballistic/rifle/boltaction/enfield
 	name = "Lee Enfield"
+	desc = "A heavy and versatile rifle, rechambered in the powerful 7.62x51mm cartridge."
 	eng_desc = "A heavy and versatile rifle, rechambered in the powerful 7.62x51mm cartridge."
 	icon_state = "enfield"
 	item_state = "enfield"


### PR DESCRIPTION
- - -
QoL:
 - You can now scope in with shift+v while a firearm is in your main hand. You otherwise still need to use the button at the top left of your screen. This should make combat much easier and more engaging. I took this from my other server, Crashpoint. It had been added originally by a good friend of mine, who I'm not sure wants their name public. I'll include it if they wish such.
- - -
Corrections:
 - Shotguns should now have their proper descriptions. Maybe. Always maybe.
- - -