### PR TITLE
Monolith Immune to Psy Damage

### DIFF
--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -260,6 +260,8 @@
 	return psyloss
 
 /mob/living/proc/adjustPsyLoss(amount)
+	if(has_trait(TRAIT_BLOWOUT_IMMUNE))
+		return FALSE
 	if(status_flags & GODMODE)
 		return FALSE
 	psyloss = CLAMP((psyloss + (amount * CONFIG_GET(number/damage_multiplier))), 0, maxHealth * 2)


### PR DESCRIPTION
- - -
Balance:
 - Monolith no longer suffer from blowouts and psy damage. They can receive neither psy damage or any negative effects of blowouts(which are applied by it stacking 200 psy damage). This is achieved via a trait known as: 'TRAIT_BLOWOUT_IMMUNE'. If others wish to utilise and achieve a similar effect with other factions, see what I've done in the Monolith folder. It can also easily be applied to items, if such is wanted.
- - -