### PR TITLE
Enfield Supremacy

### DIFF
--- a/stalker/code/objects/items/weapons/ammo/bullets.dm
+++ b/stalker/code/objects/items/weapons/ammo/bullets.dm
@@ -118,7 +118,7 @@
 
 /obj/item/projectile/bullet/bullet762x51
 	damage = 52
-	armour_penetration = 0
+	armour_penetration = 40
 	range = 80
 	spread = 2
 

--- a/stalker/code/objects/items/weapons/ammo/bullets.dm
+++ b/stalker/code/objects/items/weapons/ammo/bullets.dm
@@ -104,10 +104,10 @@
 	spread = 3
 
 /obj/item/projectile/bullet/bullet762x54
-	damage = 64
-	armour_penetration = 20
+	damage = 75
+	armour_penetration = 50
 	range = 80
-	spread = 2
+	spread = 1
 
 //DShK - Just a PKM
 /obj/item/projectile/bullet/checkpoint
@@ -117,10 +117,10 @@
 	spread = 2
 
 /obj/item/projectile/bullet/bullet762x51
-	damage = 52
+	damage = 65
 	armour_penetration = 40
 	range = 80
-	spread = 2
+	spread = 1
 
 /obj/item/projectile/bullet/tungsten_slug
 	damage = 75

--- a/stalker/code/objects/items/weapons/melee.dm
+++ b/stalker/code/objects/items/weapons/melee.dm
@@ -24,6 +24,7 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "stabbed", "torn", "ripped")
 	sharpness = IS_SHARP_ACCURATE
+	bayonet = TRUE
 	//butcher_speed = 1.25
 
 /obj/item/kitchen/knife/throwing


### PR DESCRIPTION
- - -
Balance:
 - SVD is now the highest pen gun in the game. There is reason to use it.
 - Enfield is the highest pen gun in the game round start. It's inferior in all ways except cost to run it in comparison to the SVD.
 - VSS retains its place as an assault rifle / marksman rifle hybrid, not being touched.
 - The Bayonet can now be used as, you'd expect, a Bayonet. This doesn't include the M9.
- - -