### PR TITLE
Knife Edits

### DIFF
--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -40,7 +40,7 @@
 		/obj/item/scalpel, /obj/item/reagent_containers/syringe, /obj/item/dnainjector,
 		/obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/dropper,
 		/obj/item/implanter, /obj/item/screwdriver, /obj/item/weldingtool/mini,
-		/obj/item/firing_pin
+		/obj/item/firing_pin, /obj/item/weapon/kitchen/knife/hunting, /obj/item/weapon/kitchen/knife/m9
 		))
 
 /datum/component/storage/concrete/pockets/shoes/clown/Initialize()

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -196,6 +196,7 @@
 	throwforce = 20
 	sharpness = IS_SHARP_ACCURATE
 	slot_flags = ITEM_SLOT_BELT
+	w_class = WEIGHT_CLASS_SMALL
 	hitsound = "sound/weapons/knifeswing.ogg"
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "cut")
 
@@ -209,5 +210,6 @@
 	armour_penetration = 35
 	sharpness = IS_SHARP_ACCURATE
 	slot_flags = ITEM_SLOT_BELT
+	w_class = WEIGHT_CLASS_SMALL
 	hitsound = "sound/weapons/knifeswing.ogg"
 	attack_verb = list("penetrated", "stabbed", "punctured", "impaled", "skewered", "pierced")

--- a/stalker/code/machinery/sidormat.dm
+++ b/stalker/code/machinery/sidormat.dm
@@ -300,8 +300,8 @@ GLOBAL_LIST_INIT(global_sidormat_list, list(
 		new /datum/data/stalker_equipment("Controller Brain",			"Controller Brain",	/obj/item/stalker/loot/controller_brain,	40000,		ROOKIE, sale_price = 20000),
 		/////////////////////////////////	Артефакты	///////////////////////////////////////////
 		new /datum/data/stalker_equipment("Jellyfish",			"Jellyfish",						/obj/item/artifact/meduza,					5000,	ROOKIE,	sale_price = 2500),
-		new /datum/data/stalker_equipment("Stone Flower",		"Stone Flower",						/obj/item/artifact/stoneflower,				10000,	ROOKIE,	sale_price = 3000),
-		new /datum/data/stalker_equipment("Night Star",			"Night Star",						/obj/item/artifact/nightstar,				30000,	ROOKIE,	sale_price = 13000),
+//		new /datum/data/stalker_equipment("Stone Flower",		"Stone Flower",						/obj/item/artifact/stoneflower,				10000,	ROOKIE,	sale_price = 3000),
+//		new /datum/data/stalker_equipment("Night Star",			"Night Star",						/obj/item/artifact/nightstar,				30000,	ROOKIE,	sale_price = 13000),
 		new /datum/data/stalker_equipment("Depleted Stone Flower",		"Depleted Stone Flower",						/obj/item/artifact/stoneflower_depleted,				5000,	ROOKIE,	sale_price = 1500),
 		new /datum/data/stalker_equipment("Depleted Night Star",			"Depleted Night Star",						/obj/item/artifact/nightstar_depleted,				10000,	ROOKIE,	sale_price = 8000),
 		new /datum/data/stalker_equipment("Soul",				"Soul",								/obj/item/artifact/soul,					80000,	ROOKIE,	sale_price = 25000),

--- a/stalker/code/objects/items/artifacts/artifacts.dm
+++ b/stalker/code/objects/items/artifacts/artifacts.dm
@@ -66,7 +66,7 @@
 	art_armor = list()
 	radiation = -2
 	level_s = 1
-
+/*
 /obj/item/artifact/stoneflower
 	name = "stone flower"
 	desc = "Born in gravitional anomalies. This artifact is found in only a few areas of the Zone. The bits of metallic compounds create a beautiful light play."
@@ -82,7 +82,7 @@
 	art_armor = list(bullet = 20)
 	radiation = 3
 	level_s = 3
-
+*/
 /obj/item/artifact/stoneflower_depleted
 	name = "depleted stone flower"
 	desc = "Born in gravitional anomalies. This artifact is found in only a few areas of the Zone. The bits of metallic compounds create a beautiful light play."


### PR DESCRIPTION
- - -
Balance:
 M9 and Hunting Knife can now be shoved into boots and pockets, as intended.
- - -
Misc:
 - Commented out Nightstar and Star Flower. They were still being used by spawners, as sub path objects. AAAAAAAAAAAAAAAAAAA
- - -