### PR TITLE
Barkeep Fix & Boozeomat Supremacy

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -312,7 +312,7 @@ var/sid_generator = 0
 				sk.fields["money"] = 85000//with enough to buy other people gear,
 				sk.fields["degree"] = 1//and marked as leader on the PDA system.
 			if(J.real_rank == "Bartender")
-				sk.fields["rating"] = 10000//Starts barkeeps at Veteran,
+				sk.fields["rating"] = 40000//Starts barkeeps at Legend,
 				sk.fields["money"] = 1500000//with a load of cash to provide quests and tasks for.
 			if(J.real_rank == "Special")
 				sk.fields["rating"] = 8000//Starts experienced stalkers at Experienced,
@@ -337,14 +337,14 @@ var/sid_generator = 0
 			sk.fields["faction_s"]	= J.faction_s
 		else
 			sk.fields["faction_s"]	= "Loners"
-
+/*
 		if(sk.fields["faction_s"] == "Bandits")
 			sk.fields["money"] = 6000
 		else if(sk.fields["faction_s"] == "Monolith")
 			sk.fields["money"] = 45000//With a lot of extra cash to gear themselves, as they're an antagonist faction.
-/*		else
-			sk.fields["money"] = 5000*/
-
+		else
+			sk.fields["money"] = 5000
+*/
 		stalkers += sk
 	return
 

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -331,7 +331,8 @@ var/sid_generator = 0
 			if(J.real_rank == "Bandit")
 				sk.fields["rating"] = 8000//Starts Bandits at Experienced.
 			if(J.real_rank == "Monolith")
-				sk.fields["rating"] = 8000//Starts Monolith at Experienced.
+				sk.fields["rating"] = 8000//Starts Monolith at Experienced,
+				sk.fields["money"] = 45000//with a lot of extra cash to gear themselves, as they're an antagonist faction.
 			if(J.real_rank == "Renegade")
 				sk.fields["rating"] = 8000//Starts Renegade at Experienced.
 			sk.fields["faction_s"]	= J.faction_s

--- a/code/modules/vending/boozeomat.dm
+++ b/code/modules/vending/boozeomat.dm
@@ -46,6 +46,8 @@
 /obj/machinery/vending/boozeomat/all_access
 	desc = "A technological marvel, supposedly able to mix just the mixture you'd like to drink the moment you ask for one. This model appears to have no access restrictions."
 	req_access = null
+	scan_id = 0
+	onstation = FALSE
 
 /obj/machinery/vending/boozeomat/pubby_maint //abandoned bar on Pubbystation
 	products = list(/obj/item/reagent_containers/food/drinks/bottle/whiskey = 1,


### PR DESCRIPTION
- - -
Bugfixes:
 - Barkeeps now start with their appropriate amount of cash and at Legendary.
 - Boozeomats are no longer locked. Apologies to Barkeeps for this prior to now.
- - -