### PR TITLE
Poltergeist Loot

### DIFF
--- a/stalker/code/machinery/sidormat.dm
+++ b/stalker/code/machinery/sidormat.dm
@@ -298,6 +298,7 @@ GLOBAL_LIST_INIT(global_sidormat_list, list(
 		new /datum/data/stalker_equipment("Bloodsucker Tendrils",		"Bloodsucker Tendrils",	/obj/item/stalker/loot/bloodsucker,			16000,		ROOKIE, sale_price = 8000),
 		new /datum/data/stalker_equipment("Pseudodog Tail",				"Pseudodog Tail",		/obj/item/stalker/loot/pseudo_tail,			8000,		ROOKIE, sale_price = 7000),
 		new /datum/data/stalker_equipment("Controller Brain",			"Controller Brain",	/obj/item/stalker/loot/controller_brain,	40000,		ROOKIE, sale_price = 20000),
+		new /datum/data/stalker_equipment("Poltergeist Skin",			"Poltergeist Skin",	/obj/item/stalker/loot/poltergeist_skin,	80000,		ROOKIE, sale_price = 40000),
 		/////////////////////////////////	Артефакты	///////////////////////////////////////////
 		new /datum/data/stalker_equipment("Jellyfish",			"Jellyfish",						/obj/item/artifact/meduza,					5000,	ROOKIE,	sale_price = 2500),
 //		new /datum/data/stalker_equipment("Stone Flower",		"Stone Flower",						/obj/item/artifact/stoneflower,				10000,	ROOKIE,	sale_price = 3000),

--- a/stalker/code/mobs/hostiles/mutants/mutants.dm
+++ b/stalker/code/mobs/hostiles/mutants/mutants.dm
@@ -557,6 +557,7 @@
 	robust_searching = 1
 	melee_damage_upper = 25
 	melee_damage_lower = 15
+	loot = list(/obj/item/stalker/loot/poltergeist_skin)
 	attack_sound = 	list('stalker/sound/mobs/mutants/special/poltergeist/attack_0.ogg',
 						'stalker/sound/mobs/mutants/special/poltergeist/attack_1.ogg',
 						'stalker/sound/mobs/mutants/special/poltergeist/attack_2.ogg',

--- a/stalker/code/objects/items/weapons/loot.dm
+++ b/stalker/code/objects/items/weapons/loot.dm
@@ -37,4 +37,10 @@
 	desc = "A brain. You can feel the psy-waves unconfortably pushing into your thoughts when you hold it."
 	icon_state = "controller_brain"
 
+
+/obj/item/stalker/loot/poltergeist_skin
+	name = "poltergeist flesh"
+	desc = "A chunk of flesh taken from a Poltergeist. It seems to be very slightly moving on its own, somehow."
+	icon_state = "myaso"
+
 	// Meat for cooking after this soon.


### PR DESCRIPTION
- - -
Balance:
 - Poltergeists now drop a chunk of flesh that's worth eighty-thousand. This seemed appropriate, given there's only five of them, and sometimes you can't find them at all. This, indirectly, also provides Barkeeps a manner of confirming kills.
- - -