### PR TITLE
Defib Fix

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -293,7 +293,7 @@
 	var/req_defib = TRUE
 	var/combat = FALSE //If it penetrates armor and gives additional functionality
 	var/grab_ghost = FALSE
-	var/tlimit = DEFIB_TIME_LIMIT * 10
+	var/tlimit = DEFIB_TIME_LIMIT * 10000
 
 	var/datum/component/mobhook
 


### PR DESCRIPTION
Defib revive times always fail due to the body decay in game. Changed the tlimit to be MUCH larger so that you actually have time to recover a body and defib it.

change: tlimit from 10 to 10,000.