### PR TITLE
Fix Psyblock Recipie

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -268,7 +268,7 @@
 	name = "Psyblock"
 	id = "psyblock"
 	results = list("psyblock" = 5)
-	required_reagents = list( "carbon" = 2, "water" = 2, "lithium" = 1, "unknownsubstancefour")
+	required_reagents = list( "carbon" = 2, "water" = 2, "lithium" = 1, "unknownsubstancefour" = 1)
 
 /datum/chemical_reaction/cocaine
 	name = "Cocaine"


### PR DESCRIPTION
Psyblock recipie previosly did not work due to a missing value.

Changes: Added "= 1" To the "unknownsubstancefour" requirement to create Psyblock.